### PR TITLE
Fix invalid nesting of li items

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -278,7 +278,9 @@ export const Nav = withRouter<NavItemsProps>(({ items, options, ...remaining }) 
 
     return (
         <div className={options.navClass}>
+        <ul>
             {items.map(x => <NavLink key={x.href || x.label} item={x} options={options} />)}
+        </ul>
         </div>
     );
 });


### PR DESCRIPTION
Nav component renders a list of <li> elements within a <div>. This is invalid nesting and raises an error in accessibility testers. PR adds <ul> tags wrapping the navigation items.